### PR TITLE
Fixes #2 & #8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ your own appkey from spotify if you don't trust me.
 Spotifyd requires Spotify Premium. This is a requirement on all applications using
 libspotify unfortunately.
 
+## Note for PulseAudio users
+spotifyd uses libalsa to play audio. If you are running a distribution that
+uses pulseaudio, this means that you may not be able to play audio via ALSA
+and PulseAudio at the same time. To fix this, audio from alsa needs to be
+piped to pulseaudio.
+
+For Arch Linux users, this can be done by simply installing the
+[pulseaudio-alsa](https://www.archlinux.org/packages/extra/any/pulseaudio-alsa/) package.
+
 ## License
 The project is licensed under GPLv3 with the exception of the files audio.h,
 audio.c and alsa-audio.c that are from the libspotify examples. The function

--- a/src/queue.c
+++ b/src/queue.c
@@ -60,14 +60,18 @@ bool queue_add_track(sp_track *track)
 int queue_get_next()
 {
 	int next_track;
-	if(queue_random)
-	{
-		next_track = rand()%queue_len;
-	}
-	else
-	{
-		next_track = (queue_position + 1)%queue_len;
-	}
+    /* Avoid division by zero */
+    if(queue_len > 0)
+    {
+        if(queue_random)
+        {
+            next_track = rand()%queue_len;
+        }
+        else
+        {
+            next_track = (queue_position + 1)%queue_len;
+        }
+    }
 	return next_track;
 }
 
@@ -75,14 +79,17 @@ int queue_get_prev()
 {
 	srand(time(NULL));
 	int prev_track;
-	if(queue_random)
-	{
-		prev_track = rand()%queue_len;
-	}
-	else
-	{
-		prev_track = (queue_position - 1)%queue_len;
-	}
+    if(queue_len > 0)
+    {
+        if(queue_random)
+        {
+            prev_track = rand()%queue_len;
+        }
+        else
+        {
+            prev_track = (queue_position - 1)%queue_len;
+        }
+    }
 	return prev_track;
 }
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -60,18 +60,18 @@ bool queue_add_track(sp_track *track)
 int queue_get_next()
 {
 	int next_track;
-    /* Avoid division by zero */
-    if(queue_len > 0)
-    {
-        if(queue_random)
-        {
-            next_track = rand()%queue_len;
-        }
-        else
-        {
-            next_track = (queue_position + 1)%queue_len;
-        }
-    }
+	/* Avoid division by zero */
+	if(queue_len > 0)
+	{
+		if(queue_random)
+		{
+			next_track = rand()%queue_len;
+		}
+		else
+		{
+			next_track = (queue_position + 1)%queue_len;
+		}
+	}
 	return next_track;
 }
 
@@ -79,17 +79,17 @@ int queue_get_prev()
 {
 	srand(time(NULL));
 	int prev_track;
-    if(queue_len > 0)
-    {
-        if(queue_random)
-        {
-            prev_track = rand()%queue_len;
-        }
-        else
-        {
-            prev_track = (queue_position - 1)%queue_len;
-        }
-    }
+	if(queue_len > 0)
+	{
+		if(queue_random)
+		{
+			prev_track = rand()%queue_len;
+		}
+		else
+		{
+			prev_track = (queue_position - 1)%queue_len;
+		}
+	}
 	return prev_track;
 }
 


### PR DESCRIPTION
The floating point exception people were running into is caused by the queue being empty and then trying next/prev which uses the modulus operator on `queue_len`, which is 0 if it is empty, resulting in division by zero.

The problem with spotifyd 'grabbing' audio turned out not to be a problem with spotifyd. See the commit message for details.