### PR TITLE
Close alsa if no song is playing, fixes #16

### DIFF
--- a/src/alsa-audio.c
+++ b/src/alsa-audio.c
@@ -185,7 +185,7 @@ static void* alsa_audio_start(void *aux)
 	audio_fifo_data_t *afd;
 
 	for (;;) {
-		afd = audio_get(af);
+		afd = audio_get(af, &h);
 
 		if (!h || cur_rate != afd->rate || cur_channels != afd->channels) {
 			if (h) snd_pcm_close(h);

--- a/src/audio.h
+++ b/src/audio.h
@@ -30,6 +30,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <sys/queue.h>
+#include <asoundlib.h>
 
 
 /* --- Types --- */
@@ -53,6 +54,6 @@ typedef struct audio_fifo {
 extern void audio_init(audio_fifo_t *af);
 void set_volume(double new_volume);
 extern void audio_fifo_flush(audio_fifo_t *af);
-audio_fifo_data_t* audio_get(audio_fifo_t *af);
+audio_fifo_data_t* audio_get(audio_fifo_t *af, snd_pcm_t **h);
 
 #endif /* _JUKEBOX_AUDIO_H_ */


### PR DESCRIPTION
This small fix closes the alsa device if no audio data to play is available.
It automatically gets reopened when there is something to play.

I tried to make as less changes as possible and these changes seemed to be the
easiest way to achieve this. If you got any other idea please let me know!